### PR TITLE
updating redis-launcher

### DIFF
--- a/redis/alpine/promote.sh
+++ b/redis/alpine/promote.sh
@@ -2,11 +2,11 @@
 MASTERIP=$6
 
 # Convert the IP of the promoted pod to a hostname
-MASTERPOD=`kubectl get pod -o jsonpath='{range .items[*]}{.metadata.name} {..podIP} {.status.containerStatuses[0].state}{"\n"}{end}' -l redis-role=slave --sort-by=.metadata.name|grep running|grep $MASTERIP|awk '{print $1}'`
+MASTERPOD=`kubectl get pod -o jsonpath='{range .items[*]}{.metadata.name} {..podIP} {.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' -l redis-role=slave --sort-by=.metadata.name|grep True|awk '{print $1}'`
 echo "PROMO ARGS: $@"
 echo "PROMOTING $MASTERPOD ($MASTERIP) TO MASTER"
 kubectl label --overwrite pod $MASTERPOD redis-role="master"
 
 # Demote anyone else who jumped to master
-kubectl get pod -o jsonpath='{range .items[*]}{.metadata.name} {.status.containerStatuses[0].state}{"\n"}{end}' -l redis-role=master --sort-by=.metadata.name|grep running|awk '{print $1}'|grep $REDIS_CHART_PREFIX|grep -v $MASTERPOD|xargs -n1 -I% kubectl label --overwrite pod % redis-role="slave"
+kubectl get pod -o jsonpath='{range .items[*]}{.metadata.name} {.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' -l redis-role=master --sort-by=.metadata.name|grep True|awk '{print $1}'|grep $REDIS_CHART_PREFIX|grep -v $MASTERPOD|xargs -n1 -I% kubectl label --overwrite pod % redis-role="slave"
 echo "OTHER MASTERS $MASTERS"

--- a/redis/alpine/redis-launcher.sh
+++ b/redis/alpine/redis-launcher.sh
@@ -61,7 +61,7 @@ function launchmaster() {
   fi
 
   if [ -n "$REDIS_PASS" ]; then
-    sed -i "s/# requirepass ${REDIS_PASS} \n#/" $MASTER_CONF
+    sed -i "s/# requirepass/requirepass ${REDIS_PASS} \n#/" $MASTER_CONF
   fi
 
   redis-server $MASTER_CONF --protected-mode no $@

--- a/redis/alpine/redis-launcher.sh
+++ b/redis/alpine/redis-launcher.sh
@@ -61,7 +61,7 @@ function launchmaster() {
   fi
 
   if [ -n "$REDIS_PASS" ]; then
-    sed -i "s/# /requirepass ${REDIS_PASS} \n#/" $MASTER_CONF
+    sed -i "s/# requirepass ${REDIS_PASS} \n#/" $MASTER_CONF
   fi
 
   redis-server $MASTER_CONF --protected-mode no $@

--- a/redis/alpine/redis-launcher.sh
+++ b/redis/alpine/redis-launcher.sh
@@ -61,7 +61,7 @@ function launchmaster() {
   fi
 
   if [ -n "$REDIS_PASS" ]; then
-    sed -i "s/# requirepass/requirepass ${REDIS_PASS} \n#/" $MASTER_CONF
+    sed -i "s/# 1/requirepass ${REDIS_PASS} \n#/" $MASTER_CONF
   fi
 
   redis-server $MASTER_CONF --protected-mode no $@
@@ -75,7 +75,7 @@ function launchsentinel() {
 
   while true; do
     # The sentinels must wait for a load-balanced master to appear then ask it for its actual IP.
-    MASTER_IP=$(kubectl get pod -o jsonpath='{range .items[*]}{.metadata.name} {..podIP} {.status.containerStatuses[0].state}{"\n"}{end}' -l redis-role=master|grep running|grep $REDIS_CHART_PREFIX|awk '{print $2}'|xargs)
+    MASTER_IP=$(kubectl get pod -o jsonpath='{range .items[*]}{.metadata.name} {..podIP} {.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' -l redis-role=master | grep True |grep $REDIS_CHART_PREFIX|awk '{print $2}'|xargs)
     echo "Current master is $MASTER_IP"
 
     if [[ -z ${MASTER_IP} ]]; then
@@ -159,10 +159,10 @@ fi
 
 # Determine whether this should be a master or slave instance
 echo "Looking for pods running as master"
-MASTERS=`kubectl get pod -o jsonpath='{range .items[*]}{.metadata.name} {..podIP} {.status.containerStatuses[0].state}{"\n"}{end}' -l redis-role=master|grep running|grep $REDIS_CHART_PREFIX`
+MASTERS=`kubectl get pod -o jsonpath='{range .items[*]}{.metadata.name} {..podIP} {.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' -l redis-role=master | grep True|grep $REDIS_CHART_PREFIX`
 if [[ "$MASTERS" == "" ]]; then
   echo "No masters found: \"$MASTERS\" Electing first master..."
-  SLAVE1=`kubectl get pod -o jsonpath='{range .items[*]}{.metadata.creationTimestamp} {.metadata.name} {.status.containerStatuses[0].state} {"\n"} {end}' -l redis-node=true |grep running|sort|awk '{print $2}'|grep $REDIS_CHART_PREFIX|head -n1`
+  SLAVE1=`kubectl get pod -o jsonpath='{range .items[*]}{.metadata.creationTimestamp} {.metadata.name} {.status.conditions[?(@.type=="Ready")].status} {"\n"} {end}' -l redis-node=true |grep True|sort|awk '{print $2}'|grep $REDIS_CHART_PREFIX|head -n1`
   if [[ "$SLAVE1" == "$HOSTNAME" ]] || [[ "$SLAVE1" == "" ]]; then
     echo "Taking master role"
     launchmaster

--- a/redis/alpine/redis-launcher.sh
+++ b/redis/alpine/redis-launcher.sh
@@ -61,7 +61,7 @@ function launchmaster() {
   fi
 
   if [ -n "$REDIS_PASS" ]; then
-    sed -i "s/# 1/requirepass ${REDIS_PASS} \n#/" $MASTER_CONF
+    sed -i "s/# /requirepass ${REDIS_PASS} \n#/" $MASTER_CONF
   fi
 
   redis-server $MASTER_CONF --protected-mode no $@


### PR DESCRIPTION
updated the way we get the current pod status, as the ".status.containerStatuses[0].state" are always "Running" after the first launch, and not updated specially when the physical node lost!

N.B: .status.containerStatuses[0].state is meant to scheduler to update it while the creation and holds the values as [this refernces](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#containerstate-v1-core)