### PR TITLE
Fixed redis slave IP discovery mechanism to use POD ip instead of host

### DIFF
--- a/redis/alpine/redis-launcher.sh
+++ b/redis/alpine/redis-launcher.sh
@@ -139,6 +139,7 @@ function launchslave() {
 
   sed -i "s/%master-ip%/${MASTER_LB_HOST}/" $SLAVE_CONF
   sed -i "s/%master-port%/${MASTER_LB_PORT}/" $SLAVE_CONF
+  sed -i "s/%slave-ip%/$(hostname -i)/" $SLAVE_CONF
   redis-server $SLAVE_CONF --protected-mode no $@
 }
 

--- a/redis/alpine/redis-slave.conf
+++ b/redis/alpine/redis-slave.conf
@@ -205,6 +205,7 @@ dir /redis-master-data
 #    and resynchronize with them.
 #
 slaveof %master-ip% %master-port%
+slave-announce-ip %slave-ip%
 
 # If the master is password protected (using the "requirepass" configuration
 # directive below) it is possible to tell the slave to authenticate before


### PR DESCRIPTION
Redis was discovering HOST IP instead of POD IP. Updated slave configuration to correctly announce slave IP.